### PR TITLE
allow setting a version suffix for desktop files client blueprint

### DIFF
--- a/nextcloud-client/nextcloud-client.py
+++ b/nextcloud-client/nextcloud-client.py
@@ -4,6 +4,7 @@ from Package.CMakePackageBase import *
 class subinfo(info.infoclass):
     def registerOptions(self):
         self.options.dynamic.registerOption("devMode", False)
+        self.options.dynamic.registerOption("versionSuffix", "")
         if CraftCore.compiler.isMacOS:
             self.options.dynamic.registerOption("osxArchs", "arm64")
             self.options.dynamic.registerOption("buildMacOSBundle", True)
@@ -43,13 +44,15 @@ class Package(CMakePackageBase):
         def boolToCmakeBool(value: bool) -> str:
             return "ON" if value else "OFF"
 
+        devMode = self.subinfo.options.dynamic.devMode
+        versionSuffix = self.subinfo.options.dynamic.versionSuffix
+
         if CraftCore.compiler.isMacOS:
             osxArchs = self.subinfo.options.dynamic.osxArchs
             buildAppBundle = boolToCmakeBool(self.subinfo.options.dynamic.buildMacOSBundle)
             buildFileProviderModule = boolToCmakeBool(self.subinfo.options.dynamic.buildFileProviderModule)
             sparkleLibPath = self.subinfo.options.dynamic.sparkleLibPath
             overrideServerUrl = self.subinfo.options.dynamic.overrideServerUrl
-            devMode = self.subinfo.options.dynamic.devMode
             self.subinfo.options.configure.args += [
                 f"-DCMAKE_OSX_ARCHITECTURES={osxArchs}",
                 f"-DBUILD_OWNCLOUD_OSX_BUNDLE={buildAppBundle}",
@@ -64,8 +67,9 @@ class Package(CMakePackageBase):
                     f"-DAPPLICATION_SERVER_URL={overrideServerUrl}",
                     f"-DAPPLICATION_SERVER_URL_ENFORCE={forceOverrideServerUrl}"
                 ]
-            if devMode:
-                self.subinfo.options.configure.args += [f"-DNEXTCLOUD_DEV=ON"]
+        if devMode:
+            self.subinfo.options.configure.args += [f"-DNEXTCLOUD_DEV=ON"]
+        self.subinfo.options.configure.args += [f"-DMIRALL_VERSION_SUFFIX={versionSuffix}"]
 
     def createPackage(self):
         self.blacklist_file.append(os.path.join(self.packageDir(), 'blacklist.txt'))


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
