### PR TITLE
add explicit import for CraftHash

### DIFF
--- a/libs/libp11/libp11.py
+++ b/libs/libp11/libp11.py
@@ -3,6 +3,7 @@ import info
 import shutil
 from Package.AutoToolsPackageBase import *
 from Package.MakeFilePackageBase import *
+from Utils import CraftHash
 
 
 class subinfo(info.infoclass):


### PR DESCRIPTION
should fix failing Windows and macOS CI builds

tested it locally on macOS, with that change `craft libp11` succeeded.