### PR TITLE
fix(libs/libp11): switch to dev-utils/pkgconf

### DIFF
--- a/libs/libp11/libp11.py
+++ b/libs/libp11/libp11.py
@@ -3,6 +3,7 @@ import info
 import os
 import shutil
 import utils
+from CraftBase import CraftBase
 from CraftCompiler import CraftCompiler
 from Package.AutoToolsPackageBase import *
 from Package.MakeFilePackageBase import *
@@ -24,7 +25,11 @@ class subinfo(info.infoclass):
         self.runtimeDependencies["virtual/base"] = None
         self.buildDependencies["libs/openssl"] = None
         self.buildDependencies["dev-utils/msys"] = None
-        self.buildDependencies["dev-utils/pkg-config"] = None
+        if CraftBase.cacheVersion() == "25.03-nc":
+            # support building libp11 with older cache versions if needed
+            self.buildDependencies["dev-utils/pkg-config"] = None
+        else:
+            self.buildDependencies["dev-utils/pkgconf"] = None
 
 
 class PackageMake(MakeFilePackageBase):


### PR DESCRIPTION
This change also contains a fallback that (should :crossed_fingers:) allow builds requiring the previous cache version to still work

Fixes #28 

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
