### PR TITLE
fix: add missing doc about the QT_PLUGIN_PATH environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ craft --install-deps nextcloud-client
 > ```
 > set "PATH=C:\CraftRoot\bin;C:\CraftRoot\dev-utils\bin;%PATH%"
 > ```
+> You also need to set the Qt path for plugins via an environment variable
+> ```
+> set "QT_PLUGIN_PATH=C:\CraftRoot\bin\plugins"
+> ```
 > This will result in using the `cmake` version downloaded with `KDE Craft`.
 5. Clone the desktop client repository.
 ```


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
