### PR TITLE
Optional QtWebEngine

### DIFF
--- a/nextcloud-client/nextcloud-client.py
+++ b/nextcloud-client/nextcloud-client.py
@@ -5,6 +5,7 @@ class subinfo(info.infoclass):
     def registerOptions(self):
         self.options.dynamic.registerOption("devMode", False)
         self.options.dynamic.registerOption("versionSuffix", "")
+        self.options.dynamic.registerOption("buildWithWebEngine", True)
         if CraftCore.compiler.isMacOS:
             self.options.dynamic.registerOption("osxArchs", "arm64")
             self.options.dynamic.registerOption("buildMacOSBundle", True)
@@ -26,7 +27,10 @@ class subinfo(info.infoclass):
         self.buildDependencies["dev-utils/cmake"] = None
         self.runtimeDependencies["libs/qt6/qtbase"] = None
         self.runtimeDependencies["libs/qt6/qtdeclarative"] = None
-        self.runtimeDependencies["libs/qt6/qtwebengine"] = None
+
+        if self.options.dynamic.buildWithWebEngine:
+            self.runtimeDependencies["libs/qt6/qtwebengine"] = None
+
         self.runtimeDependencies["libs/qt6/qtwebsockets"] = None
         self.runtimeDependencies["libs/qt6/qtmultimedia"] = None
         self.runtimeDependencies["libs/qt/qtsvg"] = None
@@ -62,6 +66,9 @@ class Package(CMakePackageBase):
             self.subinfo.options.configure.args += [f"-DNEXTCLOUD_DEV=ON"]
 
         self.subinfo.options.configure.args += [f"-DMIRALL_VERSION_SUFFIX={versionSuffix}"]
+
+        buildWithWebEngine = boolToCmakeBool(self.subinfo.options.dynamic.buildWithWebEngine)
+        self.subinfo.options.configure.args += [f"-DBUILD_WITH_WEBENGINE={buildWithWebEngine}"]
 
         if CraftCore.compiler.isMacOS:
             osxArchs = self.subinfo.options.dynamic.osxArchs


### PR DESCRIPTION
## Summary

- Register a new `buildWithWebEngine` option (default: `True`) to allow disabling QtWebEngine at build time
- Make the `libs/qt6/qtwebengine` runtime dependency conditional on the new option
- Pass `-DBUILD_WITH_WEBENGINE=ON/OFF` to CMake so the client skips compiling and linking WebEngine code when disabled

## Motivation

The upstream desktop client has a `BUILD_WITH_WEBENGINE` CMake option, but setting it to `OFF` alone does not prevent `QtWebEngineCore.framework` from ending up in the app bundle. That is because this blueprint unconditionally declares `libs/qt6/qtwebengine` as a runtime dependency. Craft therefore always installs the full WebEngine into its prefix, and `macdeployqt` bundles it regardless of whether the client binary actually links against it.

The goal is to allow developer builds to exclude QtWebEngine entirely. WebEngine is only required for the Global Scale sign-in flow, which is not used in daily development. Skipping it avoids downloading, building, and bundling one of the largest Qt modules, significantly accelerating local build times.

A corresponding `--without-web-engine` flag has been added to the `mac-crafter` build tool in the main desktop repository, which passes `nextcloud-client.buildWithWebEngine=False` through to this blueprint.

## Test plan

- [ ] Build with `--without-web-engine` and verify `QtWebEngineCore.framework` is absent from the app bundle
- [ ] Build without the flag (default) and verify WebEngine is still included and functional