### PR TITLE
fix: on linux add a new dependency on kdbusaddons from KDE

### DIFF
--- a/nextcloud-client/nextcloud-client.py
+++ b/nextcloud-client/nextcloud-client.py
@@ -40,6 +40,9 @@ class subinfo(info.infoclass):
         self.runtimeDependencies["libs/kdsingleapplication"] = None
         self.runtimeDependencies["qt-libs/qtkeychain"] = None
         self.runtimeDependencies["kde/frameworks/tier1/karchive"] = None
+        if CraftCore.compiler.isLinux:
+            self.runtimeDependencies["kde/frameworks/tier1/kdbusaddons"] = None
+
         self.runtimeDependencies["libs/openssl"] = None
 
 class Package(CMakePackageBase):


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
