### PR TITLE
Drop Qt Multimedia

### DIFF
--- a/nextcloud-client/nextcloud-client.py
+++ b/nextcloud-client/nextcloud-client.py
@@ -35,7 +35,6 @@ class subinfo(info.infoclass):
             self.runtimeDependencies["libs/qt6/qtwebengine"] = None
 
         self.runtimeDependencies["libs/qt6/qtwebsockets"] = None
-        self.runtimeDependencies["libs/qt6/qtmultimedia"] = None
         self.runtimeDependencies["libs/qt/qtsvg"] = None
         self.runtimeDependencies["libs/qt6/qt5compat"] = None
         self.runtimeDependencies["libs/zlib"] = None


### PR DESCRIPTION
Drops Qt Multimedia as a dependency. See nextcloud/desktop#9886 for more information.

## Checklist
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits.
- [x] The commit history is clean with no merge commits.
  - [How to rebase your commits](https://docs.github.com/en/get-started/using-git/about-git-rebase)
  - [How to squash commits with rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
- [ ] Uploaded screenshots from before and after for UI changes.
- [ ] [Documentation](https://github.com/nextcloud/documentation/) has been updated or is not required.
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (critical bugfixes).
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (bug/enhancement).
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target version.

## AI (if applicable)
- [ ] The content of this PR was partly or fully generated using AI
  - [ ] I have read the [guidelines for AI-assisted contributions](https://github.com/nextcloud/desktop/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
  - [ ] I have read Nextcloud's [AI Contribution Policy](https://github.com/nextcloud/.github/blob/master/AI_POLICY.md).
